### PR TITLE
refactor: remove legacy Celery naming references

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -73,7 +73,7 @@ Warum:
 - `max_workers=1` stellt sicher, dass nur 1 Testlauf gleichzeitig läuft (Tasks werden in FIFO-Queue gereiht)
 - Fehlerbehandlung: Wenn ein Task nicht gestartet werden kann, wird `TaskDispatchError` geworfen und der Run bekommt `status=ERROR` mit sichtbarer Fehlermeldung
 
-Schlüsseldatei: `backend/src/celery_app.py` — enthält `dispatch_task()`, `TaskDispatchError`, `TaskResult`
+Schlüsseldatei: `backend/src/task_executor.py` — enthält `dispatch_task()`, `TaskDispatchError`, `TaskResult`
 
 **Wichtig**: Vor `dispatch_task()` muss immer `db.commit()` aufgerufen werden, damit der Background-Thread die Daten in einer separaten DB-Session sehen kann.
 
@@ -156,7 +156,7 @@ RoboScope/
 │   │   ├── api/v1/   # Router-Aggregation
 │   │   ├── config.py # Pydantic Settings (.env)
 │   │   ├── database.py # SQLAlchemy sync + TimestampMixin
-│   │   ├── celery_app.py # In-Process TaskExecutor (ThreadPoolExecutor, NICHT Celery!)
+│   │   ├── task_executor.py # In-Process TaskExecutor (ThreadPoolExecutor)
 │   │   └── main.py   # FastAPI App Factory + Lifespan
 │   ├── tests/        # pytest Tests
 │   ├── migrations/   # Alembic (SQLite + PostgreSQL)
@@ -342,8 +342,8 @@ import src.auth.models    # noqa: F401 — FK resolution
 import src.repos.models   # noqa: F401 — FK resolution
 ```
 
-### Task-Ausführung (celery_app.py — Achtung: Name ist Legacy!)
-Die Datei heißt noch `celery_app.py`, enthält aber **kein Celery mehr**. Sie stellt bereit:
+### Task-Ausführung (task_executor.py)
+`backend/src/task_executor.py` stellt bereit:
 - `dispatch_task(func, *args, **kwargs) -> TaskResult` — Queued Task-Submission
 - `TaskDispatchError` — Exception wenn Submit fehlschlägt
 - `TaskResult` — Objekt mit `.id` (UUID)
@@ -538,7 +538,7 @@ vue-i18n v10 verwendet eine strikte Message-Syntax. Folgende Zeichen sind **rese
 - **AI LLM Client** — 0 Tests (4 Provider-APIs, Key-Handling)
 - **AI Encryption** — 0 Tests (Fernet für API-Keys)
 - **WebSocket Manager** — 0 Tests (Connect/Disconnect/Broadcast)
-- **celery_app.py (TaskExecutor)** — 0 Tests (alle Background-Tasks)
+- **task_executor.py (TaskExecutor)** — 0 Tests (alle Background-Tasks)
 - **AI Router**: 8 von 18 Endpoints ungetestet (generate, reverse, analyze, status, accept, drift)
 - **Report Router**: 5 Endpoints ungetestet (upload, html, assets, zip, delete-all)
 - ~~**Environment Tasks** — 0 Tests~~ → Behoben: 7 Tests (create_venv, install/upgrade/uninstall_package)

--- a/backend/src/ai/router.py
+++ b/backend/src/ai/router.py
@@ -9,7 +9,7 @@ from sqlalchemy.orm import Session
 from src.auth.constants import Role
 from src.auth.dependencies import get_current_user, require_role
 from src.auth.models import User
-from src.celery_app import TaskDispatchError, dispatch_task
+from src.task_executor import TaskDispatchError, dispatch_task
 from src.database import get_db
 from src.repos.models import Repository
 

--- a/backend/src/environments/router.py
+++ b/backend/src/environments/router.py
@@ -10,7 +10,7 @@ from src.auth.constants import Role
 from src.auth.dependencies import get_current_user, require_role
 from src.auth.models import User
 from sqlalchemy import select
-from src.celery_app import TaskDispatchError, dispatch_task
+from src.task_executor import TaskDispatchError, dispatch_task
 from src.database import get_db
 from src.environments.models import Environment, EnvironmentPackage
 

--- a/backend/src/execution/models.py
+++ b/backend/src/execution/models.py
@@ -59,7 +59,7 @@ class ExecutionRun(Base, TimestampMixin):
     retry_count: Mapped[int] = mapped_column(Integer, default=0)
     max_retries: Mapped[int] = mapped_column(Integer, default=0)
     timeout_seconds: Mapped[int] = mapped_column(Integer, default=3600)
-    task_id: Mapped[str | None] = mapped_column("celery_task_id", String(255), default=None)
+    task_id: Mapped[str | None] = mapped_column("celery_task_id", String(255), default=None)  # DB column name kept for migration compat
     output_dir: Mapped[str | None] = mapped_column(String(500), default=None)
     started_at: Mapped[datetime | None] = mapped_column(default=None)
     finished_at: Mapped[datetime | None] = mapped_column(default=None)

--- a/backend/src/execution/router.py
+++ b/backend/src/execution/router.py
@@ -12,7 +12,7 @@ from sqlalchemy.orm import Session
 from src.auth.constants import Role
 from src.auth.dependencies import get_current_user, require_role
 from src.auth.models import User
-from src.celery_app import TaskDispatchError, dispatch_task
+from src.task_executor import TaskDispatchError, dispatch_task
 from src.database import get_db
 from src.execution.models import RunStatus
 from src.execution.schemas import (

--- a/backend/src/main.py
+++ b/backend/src/main.py
@@ -95,7 +95,7 @@ async def lifespan(app: FastAPI):
         port_str = get_setting_value(session, "rf_mcp_port", "9090")
 
         if auto_start.lower() == "true" and env_id_str:
-            from src.celery_app import dispatch_task
+            from src.task_executor import dispatch_task
             from src.ai import rf_mcp_manager
             env_id = int(env_id_str)
             port = int(port_str)
@@ -120,7 +120,7 @@ async def lifespan(app: FastAPI):
         logger.info("Stopped rf-mcp server")
 
     # Gracefully shut down background task executor
-    from src.celery_app import shutdown_executor
+    from src.task_executor import shutdown_executor
     shutdown_executor(wait=False)
 
     from src.plugins.registry import plugin_registry

--- a/backend/src/repos/router.py
+++ b/backend/src/repos/router.py
@@ -8,7 +8,7 @@ from sqlalchemy.orm import Session
 from src.auth.constants import Role
 from src.auth.dependencies import get_current_user, require_role
 from src.auth.models import User
-from src.celery_app import TaskDispatchError, dispatch_task
+from src.task_executor import TaskDispatchError, dispatch_task
 from src.database import get_db
 from src.repos.schemas import (
     BranchResponse,

--- a/backend/src/stats/router.py
+++ b/backend/src/stats/router.py
@@ -9,7 +9,7 @@ from sqlalchemy.orm import Session
 from src.auth.constants import Role
 from src.auth.dependencies import get_current_user, require_role
 from src.auth.models import User
-from src.celery_app import dispatch_task
+from src.task_executor import dispatch_task
 from src.database import get_db
 from src.stats.analysis import run_analysis
 from src.stats.schemas import (

--- a/backend/src/task_executor.py
+++ b/backend/src/task_executor.py
@@ -2,7 +2,7 @@
 
 Uses a ThreadPoolExecutor with max_workers=1 so only one task runs at
 a time while additional submissions queue up. No external dependencies
-(Redis, Celery) are required.
+required.
 
 All task functions are plain Python callables — no decorators needed.
 """

--- a/e2e/tests/execution-analysis.spec.ts
+++ b/e2e/tests/execution-analysis.spec.ts
@@ -44,7 +44,7 @@ const mockFailedRun = {
   retry_count: 0,
   max_retries: 0,
   timeout_seconds: 3600,
-  celery_task_id: null,
+  task_id: null,
   started_at: '2026-01-15T10:00:00',
   finished_at: '2026-01-15T10:00:12',
   duration_seconds: 12.5,

--- a/e2e/tests/git-sync.spec.ts
+++ b/e2e/tests/git-sync.spec.ts
@@ -174,7 +174,7 @@ test.describe('Git Sync — E2E', () => {
       await route.fulfill({
         status: 500,
         contentType: 'application/json',
-        body: JSON.stringify({ detail: 'Celery broker unreachable' }),
+        body: JSON.stringify({ detail: 'Task executor unavailable' }),
       });
     });
 

--- a/frontend/src/types/domain.types.ts
+++ b/frontend/src/types/domain.types.ts
@@ -105,7 +105,7 @@ export interface ExecutionRun {
   retry_count: number
   max_retries: number
   timeout_seconds: number
-  celery_task_id: string | null
+  task_id: string | null
   started_at: string | null
   finished_at: string | null
   duration_seconds: number | null


### PR DESCRIPTION
## Summary
- Renames `backend/src/celery_app.py` → `backend/src/task_executor.py` and updates the module docstring
- Updates all 7 import sites across backend routers and `main.py`
- Renames `celery_task_id` → `task_id` in frontend types and E2E test fixtures
- Updates mock error message in `git-sync.spec.ts` (`Celery broker unreachable` → `Task executor unavailable`)
- Updates `CLAUDE.md` file path and section references

The DB column name (`celery_task_id`) is intentionally kept as-is to avoid requiring a migration.

## Test plan
- [x] `rg -i celery backend/src/ frontend/src/ e2e/tests/` returns zero matches (except DB column name in models.py)
- [x] Backend tests pass (`make test-backend`)
- [x] E2E tests pass for affected specs (`execution-analysis`, `git-sync`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)