### PR TITLE
fix: add colorama dependency + remove legacy Celery naming

### DIFF
--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -27,6 +27,7 @@ dependencies = [
     "apscheduler>=3.10.4",
     "pyyaml>=6.0",
     "cryptography>=43.0.0",
+    "colorama>=0.4",
     "httpx>=0.28.0",
 ]
 


### PR DESCRIPTION
## Summary
- **Add `colorama>=0.4` as explicit dependency** — The offline build script strips `[standard]` from `uvicorn` for Windows (to avoid `uvloop`), which also drops `colorama`. Adding it explicitly ensures it gets bundled in wheel downloads.
- **Remove legacy Celery naming** — Rename `celery_app.py` → `task_executor.py`, update all imports, fix references in CLAUDE.md, types, and tests. Celery was removed long ago but the naming persisted.

## Test plan
- [x] All 605 backend tests pass
- [ ] Rebuild offline dist (`./scripts/build-mac-and-linux.sh`) and verify `colorama` wheel appears in `dist/roboscope/wheels/`

🤖 Generated with [Claude Code](https://claude.com/claude-code)