### PR TITLE
release: version 0.5.0 + rename dist artifacts

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -70,7 +70,7 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
           name: roboscope-offline
-          path: dist/roboscope.zip
+          path: dist/roboscope_offline_version.zip
           retention-days: 7
 
   build-online:
@@ -103,5 +103,5 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
           name: roboscope-online
-          path: dist/roboscope-online.zip
+          path: dist/roboscope.zip
           retention-days: 7

--- a/Makefile
+++ b/Makefile
@@ -94,7 +94,10 @@ db-downgrade: ## Rollback last migration
 
 # --- Build / Distribution ---
 
-build-dist: ## Build standalone distribution ZIP
+build-dist: ## Build distribution ZIP (online, requires internet at install time)
+	./scripts/build-online-mac-and-linux.sh
+
+build-dist-offline: ## Build offline distribution ZIP (includes all wheels)
 	./scripts/build-mac-and-linux.sh
 
 # --- Cleanup ---

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -7,7 +7,7 @@ packages = ["src"]
 
 [project]
 name = "roboscope-backend"
-version = "0.1.0"
+version = "0.5.0"
 description = "RoboScope - Web-based Robot Framework Test Management Tool"
 requires-python = ">=3.11"
 dependencies = [

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "roboscope-frontend",
-  "version": "0.1.0",
+  "version": "0.5.0",
   "private": true,
   "type": "module",
   "scripts": {

--- a/scripts/build-mac-and-linux.sh
+++ b/scripts/build-mac-and-linux.sh
@@ -2,7 +2,7 @@
 # ──────────────────────────────────────────────────────────────
 # RoboScope — Build script for standalone distribution
 #
-# Creates a self-contained directory 'dist/roboscope/' that can be
+# Creates a self-contained directory 'dist/roboscope-offline/' that can be
 # zipped and deployed on any machine with Python 3.12+.
 #
 # Usage:  ./scripts/build-mac-and-linux.sh
@@ -10,9 +10,9 @@
 set -euo pipefail
 
 ROOT="$(cd "$(dirname "$0")/.." && pwd)"
-DIST="$ROOT/dist/roboscope"
+DIST="$ROOT/dist/roboscope-offline"
 
-echo "==> RoboScope Build"
+echo "==> RoboScope Build (offline)"
 echo "    Root: $ROOT"
 echo ""
 
@@ -422,13 +422,13 @@ BATEOF
 echo ""
 echo "==> Creating ZIP archive..."
 cd "$ROOT/dist"
-zip -r "roboscope.zip" roboscope/ -x "roboscope/.venv/*" "roboscope/__pycache__/*"
+zip -r "roboscope_offline_version.zip" roboscope-offline/ -x "roboscope-offline/.venv/*" "roboscope-offline/__pycache__/*"
 echo ""
 echo "==> Build complete!"
-echo "    Distribution: $ROOT/dist/roboscope.zip"
+echo "    Distribution: $ROOT/dist/roboscope_offline_version.zip"
 echo "    Directory:    $DIST"
 echo ""
 echo "To deploy:"
-echo "  1. Extract roboscope.zip"
+echo "  1. Extract roboscope_offline_version.zip"
 echo "  2. Run install-mac-and-linux.sh (Linux/Mac) or install-windows.bat (Windows)"
 echo "  3. Run start-mac-and-linux.sh (Linux/Mac) or start-windows.bat (Windows)"

--- a/scripts/build-online-mac-and-linux.sh
+++ b/scripts/build-online-mac-and-linux.sh
@@ -2,7 +2,7 @@
 # ──────────────────────────────────────────────────────────────
 # RoboScope — Build script for online distribution
 #
-# Creates a lightweight directory 'dist/roboscope-online/' that
+# Creates a lightweight directory 'dist/roboscope/' that
 # requires internet access during install (pip downloads from PyPI).
 # Much smaller than the offline build (~5 MB vs ~100 MB).
 #
@@ -11,7 +11,7 @@
 set -euo pipefail
 
 ROOT="$(cd "$(dirname "$0")/.." && pwd)"
-DIST="$ROOT/dist/roboscope-online"
+DIST="$ROOT/dist/roboscope"
 
 echo "==> RoboScope Build (online)"
 echo "    Root: $ROOT"
@@ -337,13 +337,13 @@ BATEOF
 echo ""
 echo "==> Creating ZIP archive..."
 cd "$ROOT/dist"
-zip -r "roboscope-online.zip" roboscope-online/ -x "roboscope-online/.venv/*" "roboscope-online/__pycache__/*"
+zip -r "roboscope.zip" roboscope/ -x "roboscope/.venv/*" "roboscope/__pycache__/*"
 echo ""
 echo "==> Build complete!"
-echo "    Distribution: $ROOT/dist/roboscope-online.zip"
+echo "    Distribution: $ROOT/dist/roboscope.zip"
 echo "    Directory:    $DIST"
 echo ""
 echo "To deploy (requires internet access):"
-echo "  1. Extract roboscope-online.zip"
+echo "  1. Extract roboscope.zip"
 echo "  2. Run install-mac-and-linux.sh (Linux/Mac) or install-windows.bat (Windows)"
 echo "  3. Run start-mac-and-linux.sh (Linux/Mac) or start-windows.bat (Windows)"

--- a/scripts/test-dist-mac-and-linux.sh
+++ b/scripts/test-dist-mac-and-linux.sh
@@ -28,10 +28,10 @@ for arg in "$@"; do
 done
 
 if [ "$MODE" = "online" ]; then
-  DIST="$ROOT/dist/roboscope-online"
+  DIST="$ROOT/dist/roboscope"
   BUILD_SCRIPT="$ROOT/scripts/build-online-mac-and-linux.sh"
 else
-  DIST="$ROOT/dist/roboscope"
+  DIST="$ROOT/dist/roboscope-offline"
   BUILD_SCRIPT="$ROOT/scripts/build-mac-and-linux.sh"
 fi
 

--- a/scripts/test-install-mac-and-linux.sh
+++ b/scripts/test-install-mac-and-linux.sh
@@ -1,13 +1,13 @@
 #!/usr/bin/env bash
 # ──────────────────────────────────────────────────────────────
-# Test script: verifies the install-mac-and-linux.sh inside dist/roboscope works
+# Test script: verifies the install-mac-and-linux.sh inside dist/roboscope-offline works
 #
 # Usage:  ./scripts/test-install-mac-and-linux.sh
 # ──────────────────────────────────────────────────────────────
 set -euo pipefail
 
 ROOT="$(cd "$(dirname "$0")/.." && pwd)"
-DIST="$ROOT/dist/roboscope"
+DIST="$ROOT/dist/roboscope-offline"
 TEST_DIR=$(mktemp -d)
 
 echo "==> Test: install-mac-and-linux.sh from dist"


### PR DESCRIPTION
## Summary
- Bumps version from 0.1.0 to 0.5.0 (backend + frontend)
- Online build (`roboscope.zip`) becomes the default distribution — smaller, more reliable
- Offline build renamed to `roboscope_offline_version.zip` with explicit naming
- Makefile: `make build-dist` now runs online build; new `make build-dist-offline` target

## Test plan
- [ ] E2E tests pass
- [ ] CI build workflow produces correctly named artifacts
- [ ] `make build-dist` runs the online build script
- [ ] `make build-dist-offline` runs the offline build script

🤖 Generated with [Claude Code](https://claude.com/claude-code)