### PR TITLE
feat: private registry support (index_url / extra_index_url)

### DIFF
--- a/backend/migrations/versions/001_add_registry_urls.py
+++ b/backend/migrations/versions/001_add_registry_urls.py
@@ -1,0 +1,26 @@
+"""Add index_url and extra_index_url to environments.
+
+Revision ID: 001_add_registry_urls
+Revises:
+Create Date: 2026-03-09
+"""
+
+from alembic import op
+import sqlalchemy as sa
+
+revision = "001_add_registry_urls"
+down_revision = None
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    with op.batch_alter_table("environments") as batch_op:
+        batch_op.add_column(sa.Column("index_url", sa.String(500), nullable=True))
+        batch_op.add_column(sa.Column("extra_index_url", sa.String(500), nullable=True))
+
+
+def downgrade() -> None:
+    with op.batch_alter_table("environments") as batch_op:
+        batch_op.drop_column("extra_index_url")
+        batch_op.drop_column("index_url")

--- a/backend/src/environments/models.py
+++ b/backend/src/environments/models.py
@@ -20,6 +20,8 @@ class Environment(Base, TimestampMixin):
     max_docker_containers: Mapped[int] = mapped_column(Integer, default=1)
     is_default: Mapped[bool] = mapped_column(Boolean, default=False)
     description: Mapped[str | None] = mapped_column(Text, default=None)
+    index_url: Mapped[str | None] = mapped_column(String(500), default=None)
+    extra_index_url: Mapped[str | None] = mapped_column(String(500), default=None)
     created_by: Mapped[int] = mapped_column(ForeignKey("users.id"))
 
 

--- a/backend/src/environments/schemas.py
+++ b/backend/src/environments/schemas.py
@@ -13,6 +13,8 @@ class EnvCreate(BaseModel):
     max_docker_containers: int = 1
     is_default: bool = False
     description: str | None = None
+    index_url: str | None = None
+    extra_index_url: str | None = None
 
 
 class EnvUpdate(BaseModel):
@@ -23,6 +25,8 @@ class EnvUpdate(BaseModel):
     max_docker_containers: int | None = None
     is_default: bool | None = None
     description: str | None = None
+    index_url: str | None = None
+    extra_index_url: str | None = None
 
 
 class EnvResponse(BaseModel):
@@ -35,6 +39,8 @@ class EnvResponse(BaseModel):
     max_docker_containers: int
     is_default: bool
     description: str | None = None
+    index_url: str | None = None
+    extra_index_url: str | None = None
     created_by: int
     created_at: datetime
     updated_at: datetime

--- a/backend/src/environments/service.py
+++ b/backend/src/environments/service.py
@@ -42,6 +42,8 @@ def create_environment(db: Session, data: EnvCreate, user_id: int) -> Environmen
         docker_image=data.docker_image,
         is_default=data.is_default,
         description=data.description,
+        index_url=data.index_url,
+        extra_index_url=data.extra_index_url,
         created_by=user_id,
     )
 
@@ -104,6 +106,8 @@ def clone_environment(db: Session, env: Environment, new_name: str, user_id: int
             docker_image=env.docker_image,
             is_default=False,
             description=f"Clone of {env.name}",
+            index_url=env.index_url,
+            extra_index_url=env.extra_index_url,
         ),
         user_id,
     )

--- a/backend/src/environments/tasks.py
+++ b/backend/src/environments/tasks.py
@@ -197,7 +197,12 @@ def install_package(env_id: int, package_name: str, version: str | None = None) 
             pkg_spec = f"{package_name}=={version}" if version else package_name
 
             subprocess.run(
-                pip_install_cmd(env.venv_path, pkg_spec),
+                pip_install_cmd(
+                    env.venv_path,
+                    pkg_spec,
+                    index_url=env.index_url,
+                    extra_index_url=env.extra_index_url,
+                ),
                 check=True,
                 capture_output=True,
                 text=True,
@@ -293,7 +298,13 @@ def upgrade_package(env_id: int, package_name: str) -> dict:
 
         try:
             subprocess.run(
-                pip_install_cmd(env.venv_path, "--upgrade", package_name),
+                pip_install_cmd(
+                    env.venv_path,
+                    "--upgrade",
+                    package_name,
+                    index_url=env.index_url,
+                    extra_index_url=env.extra_index_url,
+                ),
                 check=True,
                 capture_output=True,
                 text=True,

--- a/backend/src/environments/venv_utils.py
+++ b/backend/src/environments/venv_utils.py
@@ -115,10 +115,28 @@ def create_venv_cmd(venv_path: str, python_version: str | None = None) -> list[s
     return cmd
 
 
-def pip_install_cmd(venv_path: str, *packages: str) -> list[str]:
-    """Build uv pip install command targeting a venv."""
+def pip_install_cmd(
+    venv_path: str,
+    *packages: str,
+    index_url: str | None = None,
+    extra_index_url: str | None = None,
+) -> list[str]:
+    """Build uv pip install command targeting a venv.
+
+    Args:
+        venv_path: Path to the virtual environment.
+        packages: Package specifiers to install.
+        index_url: Custom primary PyPI index URL (replaces default).
+        extra_index_url: Additional index URL to search (e.g. private registry).
+    """
     uv = get_uv_path()
-    return [uv, "pip", "install", "--python", get_python_path(venv_path), *packages]
+    cmd = [uv, "pip", "install", "--python", get_python_path(venv_path)]
+    if index_url:
+        cmd += ["--index-url", index_url]
+    if extra_index_url:
+        cmd += ["--extra-index-url", extra_index_url]
+    cmd += list(packages)
+    return cmd
 
 
 def pip_uninstall_cmd(venv_path: str, *packages: str) -> list[str]:

--- a/backend/tests/environments/test_router.py
+++ b/backend/tests/environments/test_router.py
@@ -60,6 +60,15 @@ class TestCreateEnvironment:
         response = client.post(
             URL,
             json={"name": "normalized-env", "python_version": "3.12.5"},
+    def test_create_environment_with_registry_urls(self, client, admin_user):
+        response = client.post(
+            URL,
+            json={
+                "name": "registry-env",
+                "python_version": "3.12",
+                "index_url": "https://my-registry.example.com/simple/",
+                "extra_index_url": "https://extra.example.com/simple/",
+            },
             headers=auth_header(admin_user),
         )
         assert response.status_code == 201
@@ -89,6 +98,14 @@ class TestCreateEnvironment:
         response = client.post(
             URL,
             json={"name": "prerelease-env", "python_version": "3.14"},
+        assert data["name"] == "registry-env"
+        assert data["index_url"] == "https://my-registry.example.com/simple/"
+        assert data["extra_index_url"] == "https://extra.example.com/simple/"
+
+    def test_create_environment_registry_urls_default_none(self, client, admin_user):
+        response = client.post(
+            URL,
+            json={"name": "no-registry-env", "python_version": "3.12"},
             headers=auth_header(admin_user),
         )
         assert response.status_code == 201
@@ -107,6 +124,8 @@ class TestCreateEnvironment:
         assert response.status_code == 201
         data = response.json()
         assert data["python_version_warning"] is None
+        assert data["index_url"] is None
+        assert data["extra_index_url"] is None
 
     def test_create_environment_as_viewer_forbidden(self, client, viewer_user):
         response = client.post(

--- a/backend/tests/environments/test_venv_utils.py
+++ b/backend/tests/environments/test_venv_utils.py
@@ -74,6 +74,69 @@ class TestPipInstallCmd:
         ]
 
 
+    def test_with_index_url(self):
+        with (
+            patch.object(venv_utils, "get_uv_path", return_value="/usr/bin/uv"),
+            patch.object(venv_utils.sys, "platform", "linux"),
+        ):
+            cmd = venv_utils.pip_install_cmd(
+                "/my/venv", "requests", index_url="https://my-registry.example.com/simple/"
+            )
+        assert cmd == [
+            "/usr/bin/uv", "pip", "install",
+            "--python", "/my/venv/bin/python",
+            "--index-url", "https://my-registry.example.com/simple/",
+            "requests",
+        ]
+
+    def test_with_extra_index_url(self):
+        with (
+            patch.object(venv_utils, "get_uv_path", return_value="/usr/bin/uv"),
+            patch.object(venv_utils.sys, "platform", "linux"),
+        ):
+            cmd = venv_utils.pip_install_cmd(
+                "/my/venv", "requests", extra_index_url="https://extra.example.com/simple/"
+            )
+        assert cmd == [
+            "/usr/bin/uv", "pip", "install",
+            "--python", "/my/venv/bin/python",
+            "--extra-index-url", "https://extra.example.com/simple/",
+            "requests",
+        ]
+
+    def test_with_both_index_urls(self):
+        with (
+            patch.object(venv_utils, "get_uv_path", return_value="/usr/bin/uv"),
+            patch.object(venv_utils.sys, "platform", "linux"),
+        ):
+            cmd = venv_utils.pip_install_cmd(
+                "/my/venv", "requests",
+                index_url="https://main.example.com/simple/",
+                extra_index_url="https://extra.example.com/simple/",
+            )
+        assert cmd == [
+            "/usr/bin/uv", "pip", "install",
+            "--python", "/my/venv/bin/python",
+            "--index-url", "https://main.example.com/simple/",
+            "--extra-index-url", "https://extra.example.com/simple/",
+            "requests",
+        ]
+
+    def test_none_index_urls_ignored(self):
+        with (
+            patch.object(venv_utils, "get_uv_path", return_value="/usr/bin/uv"),
+            patch.object(venv_utils.sys, "platform", "linux"),
+        ):
+            cmd = venv_utils.pip_install_cmd(
+                "/my/venv", "requests", index_url=None, extra_index_url=None
+            )
+        assert cmd == [
+            "/usr/bin/uv", "pip", "install",
+            "--python", "/my/venv/bin/python",
+            "requests",
+        ]
+
+
 class TestPipUninstallCmd:
     def test_basic(self):
         with (

--- a/frontend/src/i18n/locales/de.ts
+++ b/frontend/src/i18n/locales/de.ts
@@ -295,6 +295,11 @@ export default {
       pythonVersion: 'Python Version',
       dockerImage: 'Docker Image (optional)',
       description: 'Beschreibung (optional)',
+      registrySettings: 'Private Registry Einstellungen',
+      indexUrl: 'Index URL',
+      indexUrlHint: 'Ersetzt den Standard-PyPI-Index (https://pypi.org/simple/).',
+      extraIndexUrl: 'Extra Index URL',
+      extraIndexUrlHint: 'Zusätzlicher Paketindex, der neben dem primären Index durchsucht wird.',
     },
     installDialog: {
       title: 'Paket installieren',

--- a/frontend/src/i18n/locales/en.ts
+++ b/frontend/src/i18n/locales/en.ts
@@ -295,6 +295,11 @@ export default {
       pythonVersion: 'Python Version',
       dockerImage: 'Docker Image (optional)',
       description: 'Description (optional)',
+      registrySettings: 'Private Registry Settings',
+      indexUrl: 'Index URL',
+      indexUrlHint: 'Replaces the default PyPI index (https://pypi.org/simple/).',
+      extraIndexUrl: 'Extra Index URL',
+      extraIndexUrlHint: 'Additional package index searched alongside the primary index.',
     },
     installDialog: {
       title: 'Install Package',

--- a/frontend/src/i18n/locales/es.ts
+++ b/frontend/src/i18n/locales/es.ts
@@ -295,6 +295,11 @@ export default {
       pythonVersion: 'Versión de Python',
       dockerImage: 'Imagen Docker (opcional)',
       description: 'Descripción (opcional)',
+      registrySettings: 'Configuración de registro privado',
+      indexUrl: 'URL del índice',
+      indexUrlHint: 'Reemplaza el índice PyPI predeterminado (https://pypi.org/simple/).',
+      extraIndexUrl: 'URL de índice adicional',
+      extraIndexUrlHint: 'Índice de paquetes adicional que se consulta junto al índice principal.',
     },
     installDialog: {
       title: 'Instalar paquete',

--- a/frontend/src/i18n/locales/fr.ts
+++ b/frontend/src/i18n/locales/fr.ts
@@ -295,6 +295,11 @@ export default {
       pythonVersion: 'Version Python',
       dockerImage: 'Image Docker (optionnel)',
       description: 'Description (optionnel)',
+      registrySettings: 'Paramètres du registre privé',
+      indexUrl: 'URL de l\'index',
+      indexUrlHint: 'Remplace l\'index PyPI par défaut (https://pypi.org/simple/).',
+      extraIndexUrl: 'URL d\'index supplémentaire',
+      extraIndexUrlHint: 'Index de paquets supplémentaire consulté en plus de l\'index principal.',
     },
     installDialog: {
       title: 'Installer un paquet',

--- a/frontend/src/types/api.types.ts
+++ b/frontend/src/types/api.types.ts
@@ -50,6 +50,8 @@ export interface EnvCreateRequest {
   max_docker_containers?: number
   is_default?: boolean
   description?: string | null
+  index_url?: string | null
+  extra_index_url?: string | null
 }
 
 export interface PackageCreateRequest {

--- a/frontend/src/types/domain.types.ts
+++ b/frontend/src/types/domain.types.ts
@@ -149,6 +149,8 @@ export interface Environment {
   max_docker_containers: number
   is_default: boolean
   description: string | null
+  index_url: string | null
+  extra_index_url: string | null
   created_by: number
   created_at: string
   updated_at: string

--- a/frontend/src/views/EnvironmentsView.vue
+++ b/frontend/src/views/EnvironmentsView.vue
@@ -15,7 +15,7 @@ const toast = useToast()
 const { t } = useI18n()
 
 const showAddDialog = ref(false)
-const newEnv = ref({ name: '', python_version: '3.12', docker_image: '', description: '' })
+const newEnv = ref({ name: '', python_version: '3.12', docker_image: '', description: '', index_url: '', extra_index_url: '' })
 const adding = ref(false)
 const selectedEnvId = ref<number | null>(null)
 
@@ -62,13 +62,15 @@ async function addEnvironment() {
       python_version: newEnv.value.python_version,
       docker_image: newEnv.value.docker_image || undefined,
       description: newEnv.value.description || undefined,
+      index_url: newEnv.value.index_url || undefined,
+      extra_index_url: newEnv.value.extra_index_url || undefined,
     })
     toast.success(t('environments.toasts.created'))
     if ((env as any).python_version_warning) {
       toast.warning(t('environments.toasts.pythonVersionWarning'), (env as any).python_version_warning)
     }
     showAddDialog.value = false
-    newEnv.value = { name: '', python_version: '3.12', docker_image: '', description: '' }
+    newEnv.value = { name: '', python_version: '3.12', docker_image: '', description: '', index_url: '', extra_index_url: '' }
   } catch (e: any) {
     toast.error(t('common.error'), e.response?.data?.detail || t('environments.toasts.createError'))
   } finally {
@@ -444,6 +446,19 @@ function isInstalled(envId: number, packageName: string): boolean {
           <label class="form-label">{{ t('environments.addDialog.description') }}</label>
           <textarea v-model="newEnv.description" class="form-textarea" rows="2"></textarea>
         </div>
+        <details class="registry-details">
+          <summary class="text-muted text-sm">{{ t('environments.addDialog.registrySettings') }}</summary>
+          <div class="form-group">
+            <label class="form-label">{{ t('environments.addDialog.indexUrl') }}</label>
+            <input v-model="newEnv.index_url" class="form-input" placeholder="https://pypi.org/simple/" />
+            <span class="form-hint">{{ t('environments.addDialog.indexUrlHint') }}</span>
+          </div>
+          <div class="form-group">
+            <label class="form-label">{{ t('environments.addDialog.extraIndexUrl') }}</label>
+            <input v-model="newEnv.extra_index_url" class="form-input" placeholder="https://my-registry.example.com/simple/" />
+            <span class="form-hint">{{ t('environments.addDialog.extraIndexUrlHint') }}</span>
+          </div>
+        </details>
       </form>
       <template #footer>
         <BaseButton variant="secondary" @click="showAddDialog = false">{{ t('common.cancel') }}</BaseButton>
@@ -529,6 +544,35 @@ function isInstalled(envId: number, packageName: string): boolean {
 </template>
 
 <style scoped>
+.registry-details {
+  margin-top: 8px;
+  border: 1px solid var(--color-border-light);
+  border-radius: 6px;
+  padding: 0;
+}
+
+.registry-details summary {
+  cursor: pointer;
+  padding: 8px 12px;
+  font-size: 13px;
+}
+
+.registry-details[open] summary {
+  border-bottom: 1px solid var(--color-border-light);
+  margin-bottom: 8px;
+}
+
+.registry-details .form-group {
+  padding: 0 12px 8px;
+}
+
+.form-hint {
+  display: block;
+  font-size: 12px;
+  color: var(--color-text-muted);
+  margin-top: 2px;
+}
+
 .env-details {
   padding: 16px 20px;
   border-top: 1px solid var(--color-border-light);


### PR DESCRIPTION
## Summary

Adds support for private Python package registries when creating environments.

- Adds `index_url` and `extra_index_url` fields to environment creation
- Includes DB migration for new fields
- i18n strings for all supported languages
- Unit tests for registry URL handling

## Changes
- `feat: add private registry support with index_url and extra_index_url`