### PR TITLE
fix(build): unbreak Build Distribution after heal-toggle merge

### DIFF
--- a/scripts/build-mac-and-linux.sh
+++ b/scripts/build-mac-and-linux.sh
@@ -150,12 +150,25 @@ DEPS_FILE=$(mktemp)
 _read_deps > "$DEPS_FILE"
 REQ_FILE="$DEPS_FILE"
 
+# Story HEAL-VENDORED — `robotframework-roboscopeheal` is in pyproject.toml's
+# runtime deps so `uv sync` resolves it via [tool.uv.sources], but the package
+# is NOT published on PyPI yet. Passing the unfiltered deps file to
+# `pip download` makes pip's resolver bail on the missing index entry —
+# dropping every other wheel along with it (symptom that broke main on
+# 2026-06-01: "No matching distribution found for fastapi>=0.115.0" — pip
+# never even tried, because resolution aborted upstream). Strip the line
+# for the download pass; the build produces the vendored wheel from source
+# a few steps below (RFHEAL_VENDOR block) so the offline install still
+# resolves it via --find-links.
+PIPDL_REQ_FILE=$(mktemp)
+grep -v '^robotframework-roboscopeheal' "$REQ_FILE" > "$PIPDL_REQ_FILE"
+
 # Download platform-specific binary wheels
 for pyver in 3.10 3.11 3.12 3.13 3.14; do
   abi="cp${pyver//./}"
   echo "    Downloading wheels for $WHEEL_PLATFORM (Python $pyver)..."
   python3 -m pip download \
-    -r "$REQ_FILE" \
+    -r "$PIPDL_REQ_FILE" \
     -d "$DIST/wheels" \
     --platform "$WHEEL_PLATFORM" \
     --python-version "$pyver" \
@@ -168,7 +181,7 @@ done
 # Also download for host platform (catches pure-python deps missed by cross-platform pass)
 echo "    Downloading wheels for host platform..."
 python3 -m pip download \
-  -r "$REQ_FILE" \
+  -r "$PIPDL_REQ_FILE" \
   -d "$DIST/wheels" \
   2>/dev/null || true
 
@@ -202,7 +215,7 @@ fi
 
 # Save requirements for install scripts
 cp "$REQ_FILE" "$DIST/requirements.txt"
-rm -f "$DEPS_FILE"
+rm -f "$DEPS_FILE" "$PIPDL_REQ_FILE"
 echo "    Wheels: $(ls "$DIST/wheels" | wc -l | tr -d ' ') packages"
 
 # ── 5. Create .env template ──────────────────────────────────

--- a/scripts/build-online-mac-and-linux.sh
+++ b/scripts/build-online-mac-and-linux.sh
@@ -84,6 +84,25 @@ for dep in data['project']['dependencies']:
 " > "$DIST/requirements.txt"
 echo "    Requirements: $(wc -l < "$DIST/requirements.txt" | tr -d ' ') packages"
 
+# Story HEAL-VENDORED — `robotframework-roboscopeheal>=0.2` is in the
+# extracted requirements but is NOT on PyPI yet. The online install
+# (which goes straight to PyPI) would 404 on it. Build the wheel from
+# the vendored source tree and ship a tiny wheels/ directory alongside
+# requirements.txt so the install command can resolve roboscopeheal
+# locally via --find-links, while everything else still comes from PyPI.
+RFHEAL_VENDOR="$ROOT/backend/vendor/robotframework-roboscopeheal"
+if [ -d "$RFHEAL_VENDOR" ]; then
+  echo "==> Building robotframework-roboscopeheal wheel from vendor..."
+  mkdir -p "$DIST/wheels"
+  python3 -m pip install --quiet --upgrade build 2>/dev/null || true
+  (cd "$RFHEAL_VENDOR" \
+   && python3 -m build --wheel --outdir "$DIST/wheels" 2>&1 \
+   | grep -iE "built|error|warn" || true)
+  echo "    Wheel: $(ls "$DIST/wheels"/*.whl 2>/dev/null | head -1)"
+else
+  echo "    WARN: $RFHEAL_VENDOR missing — heal library won't ship with this online bundle." >&2
+fi
+
 # ── 5. Create .env template ──────────────────────────────────
 cat > "$DIST/.env.example" << 'ENVEOF'
 # RoboScope Configuration
@@ -134,8 +153,14 @@ fi
 # Create virtual environment with uv
 uv venv .venv
 
-# Install dependencies from PyPI
-uv pip install --python .venv/bin/python -r requirements.txt
+# Install dependencies. PyPI for everything except the vendored
+# robotframework-roboscopeheal wheel that ships in wheels/ — uv resolves
+# the local wheel via --find-links and the rest from the public index.
+if [ -d wheels ]; then
+  uv pip install --python .venv/bin/python --find-links wheels -r requirements.txt
+else
+  uv pip install --python .venv/bin/python -r requirements.txt
+fi
 
 # Copy default config if not exists
 [ -f .env ] || cp .env.example .env

--- a/scripts/build-windows.ps1
+++ b/scripts/build-windows.ps1
@@ -151,6 +151,18 @@ try {
 $reqFile = Join-Path $env:TEMP "roboscope-reqs-$([guid]::NewGuid().ToString('N').Substring(0,8)).txt"
 (Get-Content $depsFile) -replace 'uvicorn\[standard\]', 'uvicorn' | Set-Content -Path $reqFile -Encoding UTF8
 
+# Story HEAL-VENDORED — `robotframework-roboscopeheal` is in pyproject.toml's
+# runtime deps so `uv sync` resolves it via [tool.uv.sources], but the
+# package is NOT on PyPI yet. Passing the unfiltered deps file to
+# `pip download` makes the resolver bail on the missing index entry,
+# dropping every other wheel along with it (the breakage that hit main on
+# 2026-06-01: "No matching distribution found for fastapi>=0.115.0").
+# Strip the line for the download pass; the build produces the vendored
+# wheel from source below so the offline install still resolves it via
+# --find-links.
+$pipDlReqFile = Join-Path $env:TEMP "roboscope-reqs-pipdl-$([guid]::NewGuid().ToString('N').Substring(0,8)).txt"
+(Get-Content $reqFile) | Where-Object { $_ -notmatch '^robotframework-roboscopeheal' } | Set-Content -Path $pipDlReqFile -Encoding UTF8
+
 # pip writes warnings/progress to stderr; temporarily allow non-terminating errors
 $oldEAP = $ErrorActionPreference
 $ErrorActionPreference = "Continue"
@@ -160,7 +172,7 @@ foreach ($pyver in @("3.10", "3.11", "3.12", "3.13", "3.14")) {
     $abi = "cp$($pyver -replace '\.','')"
     Write-Host "    Downloading wheels for $WHEEL_PLATFORM (Python $pyver)..."
     python -m pip download `
-        -r $reqFile `
+        -r $pipDlReqFile `
         -d $wheelsDir `
         --platform $WHEEL_PLATFORM `
         --python-version $pyver `
@@ -174,7 +186,7 @@ foreach ($pyver in @("3.10", "3.11", "3.12", "3.13", "3.14")) {
 # Running natively on Windows, pip correctly resolves sys_platform=='win32'
 # markers, pulling in tzdata, colorama, and other Windows-conditional deps.
 Write-Host "    Downloading wheels for host platform (native Windows resolution)..."
-python -m pip download -r $reqFile -d $wheelsDir 2>&1 | ForEach-Object { "$_" } | Out-Null
+python -m pip download -r $pipDlReqFile -d $wheelsDir 2>&1 | ForEach-Object { "$_" } | Out-Null
 
 # Ensure conditional transitive deps are included
 Write-Host "    Downloading conditional dependencies..."
@@ -182,11 +194,29 @@ foreach ($pkg in @("tomli>=2.0.0", "exceptiongroup>=1.0.0", "typing_extensions>=
     python -m pip download $pkg -d $wheelsDir --no-deps 2>&1 | ForEach-Object { "$_" } | Out-Null
 }
 
+# Story HEAL-VENDORED — build the vendored robotframework-roboscopeheal
+# wheel from source and drop it next to the pip-downloaded wheels so the
+# offline `pip install --no-index --find-links=wheels` step resolves it.
+# Mirrors the bash script's RFHEAL_VENDOR block.
+$rfhealVendor = Join-Path $ROOT "backend\vendor\robotframework-roboscopeheal"
+if (Test-Path $rfhealVendor) {
+    Write-Host "    Building robotframework-roboscopeheal wheel from vendor..."
+    python -m pip install --quiet --upgrade build 2>&1 | Out-Null
+    Push-Location $rfhealVendor
+    try {
+        python -m build --wheel --outdir $wheelsDir 2>&1 | Select-String -Pattern "built|error|warn" -CaseSensitive:$false | ForEach-Object { $_.Line }
+    } finally {
+        Pop-Location
+    }
+} else {
+    Write-Warning "$rfhealVendor missing -- heal library won't be in this Windows bundle."
+}
+
 $ErrorActionPreference = $oldEAP
 
 # Save requirements for install scripts
 Copy-Item -Force $reqFile (Join-Path $DIST "requirements.txt")
-Remove-Item -Force $depsFile, $reqFile -ErrorAction SilentlyContinue
+Remove-Item -Force $depsFile, $reqFile, $pipDlReqFile -ErrorAction SilentlyContinue
 
 $wheelCount = (Get-ChildItem -Path $wheelsDir -Filter "*.whl").Count
 Write-Host "    Wheels: $wheelCount packages"

--- a/scripts/test-dist-mac-and-linux.sh
+++ b/scripts/test-dist-mac-and-linux.sh
@@ -225,7 +225,14 @@ source .venv/bin/activate
 if [ "$MODE" = "offline" ]; then
   pip install --no-index --find-links=wheels -r requirements.txt -q 2>&1 | tail -3
 else
-  pip install -r requirements.txt -q 2>&1 | tail -3
+  # Online mode still needs `--find-links wheels` because the vendored
+  # robotframework-roboscopeheal wheel ships in wheels/ alongside
+  # requirements.txt (the package isn't on PyPI yet — see build script).
+  if [ -d wheels ]; then
+    pip install --find-links wheels -r requirements.txt -q 2>&1 | tail -3
+  else
+    pip install -r requirements.txt -q 2>&1 | tail -3
+  fi
 fi
 pass "pip install completed"
 


### PR DESCRIPTION
## Summary

- Build Distribution went red on main after PR #41 (heal-toggle) merged. Root cause: `robotframework-roboscopeheal>=0.2` is in `backend/pyproject.toml` runtime deps but not on PyPI yet — pip resolver bails on the missing index entry and drops every other wheel along with it.
- Three build scripts updated to filter the line before `pip download` (offline) and ship the vendored wheel via `--find-links` (online + offline). Final user-facing requirements.txt unchanged.
- Windows path picked up the previously missing vendored-wheel build block on the way through.

## Test plan

- [ ] Phase 4 Release Gates run green on this branch
- [ ] Build Distribution / Build Offline (linux, macos-arm64, macos-x86_64, Windows) all green
- [ ] Build Distribution / Build (Online) green
- [ ] Bundle artifacts (`roboscope_offline_*.zip`, `roboscope.zip`) exist after the run

🤖 Generated with [Claude Code](https://claude.com/claude-code)