### PR TITLE
fix(build): point online Windows installer at bundled roboheal wheel

### DIFF
--- a/scripts/build-online-mac-and-linux.sh
+++ b/scripts/build-online-mac-and-linux.sh
@@ -287,8 +287,15 @@ if %errorlevel% neq 0 (
 :: Create virtual environment with uv
 uv venv .venv
 
-:: Install dependencies from PyPI
-uv pip install --python .venv\Scripts\python.exe -r requirements.txt
+:: Install dependencies. PyPI for everything except the vendored
+:: robotframework-roboscopeheal wheel that ships in wheels\ — uv resolves
+:: the local wheel via --find-links and the rest from the public index.
+:: Without --find-links the install 404s on roboscopeheal (not on PyPI).
+if exist wheels\ (
+    uv pip install --python .venv\Scripts\python.exe --find-links wheels -r requirements.txt
+) else (
+    uv pip install --python .venv\Scripts\python.exe -r requirements.txt
+)
 
 if not exist .env copy .env.example .env
 


### PR DESCRIPTION
## Problem

The `build-online` job ships the vendored `robotframework-roboscopeheal` wheel in `wheels/` because the package is not on PyPI. The generated **mac/linux** installer resolves it via `--find-links wheels`, but the generated **Windows** `install-windows.bat` omitted `--find-links` and installed straight from PyPI — 404ing on `robotframework-roboscopeheal>=0.2`. This is the roboheal-wheel install failure on the online Windows bundle.

## Fix

Mirror the mac/linux logic in the generated `install-windows.bat`: when a `wheels/` directory is present, pass `--find-links wheels` so the local roboheal wheel resolves on Windows while everything else still comes from PyPI. The wheel is built `py3-none-any` (OS-independent), so the Linux-built wheel installs fine on Windows.

The offline Windows build (`build-windows.ps1`) was already correct (`--no-index --find-links=wheels`); this bug was only in the online bundle's Windows installer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)