### PR TITLE
fix(flow-editor): repo resources shown twice in the palette

### DIFF
--- a/e2e/tests/flow-editor-resource-ux.spec.ts
+++ b/e2e/tests/flow-editor-resource-ux.spec.ts
@@ -84,6 +84,12 @@ test.describe('Flow Editor — custom-resource UX (D1–D6)', () => {
     // D1 — the pinned "Your resources" section header is present.
     await expect(palette.locator('[data-testid="palette-resources-label"]')).toBeVisible({ timeout: 8_000 });
 
+    // Dedupe regression — the rf-knowledge search path returns repo keywords
+    // under a "library" named after the file stem ("login.resource" -> "login").
+    // Those must NOT also appear as a separate library category below; they live
+    // only in "Your resources". Assert no category is named after the stem.
+    await expect(palette.locator('.category-name', { hasText: /^login$/i })).toHaveCount(0);
+
     // D5 / D6 — sort + filter controls live in the palette header.
     await expect(palette.locator('[data-testid="palette-sort-btn"]')).toBeVisible();
     await expect(palette.locator('[data-testid="palette-filter-btn"]')).toBeVisible();

--- a/frontend/src/components/editor/flow/KeywordPalette.vue
+++ b/frontend/src/components/editor/flow/KeywordPalette.vue
@@ -16,6 +16,7 @@ import {
   applyFilter,
   hiddenCount,
   sortLibraries,
+  resourceFileStems,
   type CatLike,
 } from './paletteView'
 import type { StepType, RobotStep } from './flowConverter'
@@ -375,7 +376,14 @@ const resourceCategories = computed<KeywordCategory[]>(() => {
 const libraryCategories = computed<KeywordCategory[]>(() => {
   const libCats: KeywordCategory[] = []
   const dynamicLibNames = new Set<string>()
+  // Dedupe: the rf-knowledge search path returns repo keywords under a
+  // "library" named after the source file stem (login.resource → "login").
+  // Those keywords already render in the pinned "Your resources" section, so
+  // skip the duplicate library group. (No-op on the env-libdoc path, which
+  // never introspects resource files.)
+  const resourceStems = resourceFileStems(projectKeywords.value.map(kw => kw.file_path))
   for (const [lib, keywords] of dynamicLibraries.value) {
+    if (resourceStems.has(lib.toLowerCase())) continue
     libCats.push({
       name: lib,
       keywords: keywords.map(kw => kw.name),

--- a/frontend/src/components/editor/flow/paletteView.ts
+++ b/frontend/src/components/editor/flow/paletteView.ts
@@ -95,6 +95,26 @@ export function parseStoredSort(raw: string | null): PaletteSort | null {
   return raw === 'mostUsed' || raw === 'alpha' || raw === 'importedFirst' ? raw : null
 }
 
+/**
+ * Lower-cased stems (basename minus final extension) of the repo's project
+ * keyword files. The rf-knowledge search path attributes a repo keyword to a
+ * "library" equal to its source file stem (`backend/.../rf_knowledge.py`:
+ * `library = f.stem`), so `login.resource` keywords come back under a library
+ * group named `login`. The palette already renders those same keywords in the
+ * pinned "Your resources" section (grouped by `login.resource`), so the library
+ * group is a duplicate — this set lets the palette drop it. No-op on the
+ * env-libdoc path (which never introspects resource files).
+ */
+export function resourceFileStems(filePaths: string[]): Set<string> {
+  const stems = new Set<string>()
+  for (const p of filePaths) {
+    const base = (p.split('/').pop() || p).trim()
+    const stem = base.replace(/\.[^.]+$/, '')
+    if (stem) stems.add(stem.toLowerCase())
+  }
+  return stems
+}
+
 /** The minimal category shape these helpers reason about. */
 export interface CatLike {
   name: string

--- a/frontend/src/tests/components/PaletteView.spec.ts
+++ b/frontend/src/tests/components/PaletteView.spec.ts
@@ -13,6 +13,7 @@ import {
   bucketOf,
   parseStoredFilter,
   parseStoredSort,
+  resourceFileStems,
   SOPHISTICATED_MIN_STEPS,
   type CatLike,
   type PaletteFilter,
@@ -102,6 +103,24 @@ describe('sortLibraries (D5)', () => {
     const out = sortLibraries(libs, 'importedFirst', usage).map((l) => l.name)
     expect(out.indexOf('AppiumLibrary')).toBe(out.length - 1) // the only example → last
     expect(out.slice(0, 2).sort()).toEqual(['Browser', 'Collections'])
+  })
+})
+
+describe('resourceFileStems (dedupe vs rf-knowledge library attribution)', () => {
+  it('maps file paths to lower-cased stems (strips dir + extension)', () => {
+    const s = resourceFileStems(['resources/login.resource', 'tests/Sub/Common.robot'])
+    expect(s).toEqual(new Set(['login', 'common']))
+  })
+  it('lets the rf-knowledge "library" group (file stem) be matched & dropped', () => {
+    // rf_knowledge.py attributes a repo keyword to library = f.stem, so
+    // login.resource keywords arrive under a library named "login".
+    const stems = resourceFileStems(['resources/login.resource'])
+    expect(stems.has('login')).toBe(true)
+    expect(stems.has('browser')).toBe(false) // real libs are untouched
+  })
+  it('handles bare filenames and empty input', () => {
+    expect(resourceFileStems(['common.resource'])).toEqual(new Set(['common']))
+    expect(resourceFileStems([])).toEqual(new Set())
   })
 })
 


### PR DESCRIPTION
**Bug (reported by Thomas):** in the Flow Editor palette, a repo's `.resource` keywords show up **twice** — once in the pinned **"Your resources"** section, and again below under the library suggestions.

**Root cause:** the rf-knowledge keyword-search path imports the repo's `.robot`/`.resource` files and attributes each keyword to a `library` equal to its source-file *stem* (`backend/src/ai/rf_knowledge.py`: `library = f.stem`). So `login.resource` keywords come back grouped under a library named `login`. The D1 palette rewrite added a dedicated "Your resources" section (grouped by `login.resource`), which made the pre-existing overlap visible as a duplicate. (The env-libdoc path never introspects resource files, so it's unaffected.)

**Fix:** drop dynamic library groups whose name matches a repo resource-file stem, via a new pure helper `resourceFileStems()`. No-op on the env-libdoc path.

**Tests:**
- Unit: `resourceFileStems` (PaletteView.spec.ts).
- E2E regression guard: `flow-editor-resource-ux.spec.ts` asserts the stem never renders as its own library category.
- Type-check clean; palette specs green; resource-autoimport + resource-ux E2E green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)