### PR TITLE
fix(security): bump dompurify to >=3.4.11 (GHSA-cmwh-pvxp-8882)

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "roboscope-frontend",
-  "version": "0.9.0",
+  "version": "0.10.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "roboscope-frontend",
-      "version": "0.9.0",
+      "version": "0.10.0",
       "dependencies": {
         "@codemirror/lang-python": "^6.2.1",
         "@codemirror/language": "^6.12.1",
@@ -22,7 +22,7 @@
         "axios": "^1.15.0",
         "chart.js": "^4.4.0",
         "codemirror": "^6.0.2",
-        "dompurify": "^3.4.2",
+        "dompurify": "^3.4.11",
         "driver.js": "^1.4.0",
         "js-yaml": "^4.1.1",
         "pinia": "^2.2.0",
@@ -2178,9 +2178,9 @@
       }
     },
     "node_modules/dompurify": {
-      "version": "3.4.10",
-      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.4.10.tgz",
-      "integrity": "sha512-0xzNv0e7oYC6yyuOGZIABPM4qtg3QxLFniDNPP4ZP90wR8Yq3zgwpRbrNiT4N3IKqDbbYFEJLV+JWEs19aZ//w==",
+      "version": "3.4.11",
+      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.4.11.tgz",
+      "integrity": "sha512-zhlUV12GsaRzMsf9q5M254YhA4+VuF0fG+QFqu6aYpoGlKtz+w8//jBcGVYBgQkR5GHjUomejY84AV+/uPbWdw==",
       "license": "(MPL-2.0 OR Apache-2.0)",
       "optionalDependencies": {
         "@types/trusted-types": "^2.0.7"

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -27,7 +27,7 @@
     "axios": "^1.15.0",
     "chart.js": "^4.4.0",
     "codemirror": "^6.0.2",
-    "dompurify": "^3.4.2",
+    "dompurify": "^3.4.11",
     "driver.js": "^1.4.0",
     "js-yaml": "^4.1.1",
     "pinia": "^2.2.0",


### PR DESCRIPTION
A **new** Dependabot advisory appeared 2026-06-18 (after the #52 backend sweep): **GHSA-cmwh-pvxp-8882** — dompurify ≤3.4.10 allows permanent `ALLOWED_ATTR` pollution via `setConfig()`, bypassing the hook clone-guard (an incomplete fix of the 3.4.7 hook-pollution patch). Frontend npm, medium severity.

Our lock was pinned at 3.4.10. This bumps the floor to `>=3.4.11` and the lockfile to **3.4.11**.

## Verification
- `npm audit` → 0 vulnerabilities
- Prod build clean (dompurify is the HTML sanitizer)
- Full frontend unit suite green (854)

Last of the 0.11.0 security items — backend alerts (#52) + palette dedupe (#53) already on `main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)