### PR TITLE
feat(explorer): quiet, repo-scoped keyword loading

### DIFF
--- a/_bmad-output/implementation-artifacts/spec-keyword-loading-quiet-and-cached.md
+++ b/_bmad-output/implementation-artifacts/spec-keyword-loading-quiet-and-cached.md
@@ -1,0 +1,123 @@
+---
+title: 'Quiet, repo-scoped keyword loading in the Explorer/Flow Editor'
+type: 'refactor'
+created: '2026-06-19'
+status: 'done'
+baseline_commit: '25737b3'
+context:
+  - '{project-root}/CLAUDE.md'
+---
+
+<frozen-after-approval reason="human-owned intent — do not modify unless human renegotiates">
+
+## Intent
+
+**Problem:** Switching files in the Explorer re-runs `RobotEditor`'s file-switch
+watcher → `explorer.refreshKeywords(repoId)`, which **invalidates the backend
+libdoc cache and re-fetches the whole repo keyword set on every switch**. That
+both wastes work (the env's installed libraries — and the repo's project
+keywords — don't change between files) and flips `keywordsLoading=true`, which
+renders the prominent full-width `.keyword-loading-bar` ("Keywords aus Umgebung
+werden geladen…") again and again.
+
+**Approach:** (1) Make keyword loading **repo-scoped + idempotent**: a plain file
+switch only *ensures* the repo's keywords are loaded (no-op when already cached
+for that repo), instead of invalidating + refetching. Genuine invalidation
+(import added/removed, manual refresh, post-install) keeps using
+`refreshKeywords`. (2) Make the loading indicator **subtle** — a slim top
+progress line with a small muted label instead of the full-width bar.
+
+## Boundaries & Constraints
+
+**Always:**
+- Keyword data stays repo-scoped; the store tracks which repo `keywords` belongs
+  to and skips reloading when it already matches.
+- `refreshKeywords` (invalidate + refetch) still fires for: `libraries-changed`,
+  manual refresh button, and post-install — these legitimately need
+  re-introspection.
+- Keep the i18n string available as the indicator's accessible label
+  (`aria-label`/`title`) in all 5 locales.
+
+**Ask First:**
+- Any change to the *backend* keyword cache / introspection (this is a
+  frontend-only change).
+
+**Never:**
+- Don't remove the ability to refresh after an import change or install.
+- Don't make file switches trigger a backend cache invalidation.
+- No new dependencies.
+
+## I/O & Edge-Case Matrix
+
+| Scenario | Input / State | Expected Output / Behavior | Error Handling |
+|----------|--------------|---------------------------|----------------|
+| Switch files, same repo, keywords already loaded | `preloadKeywords(sameRepo)` | Immediate no-op; no fetch, no loading indicator | N/A |
+| Switch files, keywords not yet loaded | `preloadKeywords(repo)` | Fetches once, sets repo anchor | falls back to rf-knowledge / empty on error (unchanged) |
+| Switch to a different repo | `preloadKeywords(otherRepo)` | Repo anchor differs → loads fresh | as above |
+| Add `Library X` import | `libraries-changed` | `refreshKeywords` invalidates + refetches (unchanged) | non-critical catch (unchanged) |
+| Initial repo open while loading | `keywordsLoading=true` | Slim top line + small muted label shown | N/A |
+
+</frozen-after-approval>
+
+## Code Map
+
+- `frontend/src/stores/explorer.store.ts` -- `preloadKeywords`/`refreshKeywords`; add a `keywordsRepoId` anchor + idempotent guard.
+- `frontend/src/components/editor/RobotEditor.vue` -- file-switch watcher (~787-793) currently calls `_refreshKeywordsIfPossible()`; switch it to an ensure-loaded call. Keep `onLibrariesChanged`/install refresh paths.
+- `frontend/src/views/ExplorerView.vue` -- `.keyword-loading-bar` markup (~927-930) + styles (~1789-1812): restyle to a slim, subtle indicator.
+- `frontend/src/stores/explorer.store.ts` tests + a RobotEditor file-switch test -- pin the idempotency + no-refetch-on-switch behavior.
+
+## Tasks & Acceptance
+
+**Execution:**
+- [x] `frontend/src/stores/explorer.store.ts` -- add `keywordsRepoId` ref; `preloadKeywords(repoId)` early-returns when `keywordsLoaded && keywordsRepoId === repoId && !keywordsLoading`; set `keywordsRepoId = repoId` on successful load; reset in `clearAll`. Export `keywordsRepoId`. -- repo-scoped idempotent cache.
+- [x] `frontend/src/components/editor/RobotEditor.vue` -- in the `props.filePath` watcher, replace `_refreshKeywordsIfPossible()` with an ensure-loaded call (`explorer.preloadKeywords(repoId)`); update the comment. Leave `onLibrariesChanged` + install refresh untouched. -- stop full reload on file switch.
+- [x] `frontend/src/views/ExplorerView.vue` -- restyle the indicator to a slim 2px indeterminate top line + a small muted label; keep the i18n text as visible small label and `aria-label`. -- quieter indicator.
+- [x] `frontend/src/tests/stores/explorer.store.spec.ts` -- test: second `preloadKeywords(sameRepo)` does not refetch; different repo does; `clearAll` resets the anchor. -- pin caching.
+
+**Acceptance Criteria:**
+- Given a repo with keywords loaded, when the user switches between files in that repo, then no keyword fetch fires and the loading indicator does not reappear.
+- Given an import is added in the Flow Editor, when `libraries-changed` fires, then `refreshKeywords` still invalidates and refetches.
+- Given keywords are loading on first repo open, then the indicator is a slim line + small muted label (no full-width bar), with an accessible label.
+
+## Design Notes
+
+The libdoc cache is **per-environment** (installed libraries), and project
+keywords are **repo-wide** — neither changes when you switch files, so the
+file-switch refetch was pure waste. The fix is an idempotency anchor, not new
+caching infrastructure.
+
+## Verification
+
+**Commands:**
+- `cd frontend && npm run type-check` -- expected: clean
+- `cd frontend && npx vitest run src/tests/stores/explorer.store.spec.ts` -- expected: pass
+- `cd frontend && npm run build` -- expected: clean (no i18n escape break)
+- `cd e2e && npx playwright test explorer flow-editor-resource-ux --reporter=line` -- expected: pass (no regression in file open / palette)
+
+## Suggested Review Order
+
+**Repo-scoped caching (the core change)**
+
+- The idempotency guard — a file switch no-ops when this repo is already cached.
+  [`explorer.store.ts:151`](../../frontend/src/stores/explorer.store.ts#L151)
+- The anchor it keys off, set only on successful load.
+  [`explorer.store.ts:35`](../../frontend/src/stores/explorer.store.ts#L35)
+- File-switch watcher: ensure-loaded (`preloadKeywords`) instead of invalidate+refetch.
+  [`RobotEditor.vue:795`](../../frontend/src/components/editor/RobotEditor.vue#L795)
+
+**Concurrency / correctness (from review)**
+
+- Latest-wins re-run so a fast repo switch mid-load isn't silently dropped.
+  [`explorer.store.ts:200`](../../frontend/src/stores/explorer.store.ts#L200)
+- Error path clears the anchor so it never advertises an unloaded repo.
+  [`explorer.store.ts:196`](../../frontend/src/stores/explorer.store.ts#L196)
+
+**Quieter indicator**
+
+- Slim line + small muted label, `role="status"` + reduced-motion handling.
+  [`ExplorerView.vue:931`](../../frontend/src/views/ExplorerView.vue#L931)
+
+**Tests**
+
+- Idempotency, cross-repo reload, refresh-forces-reload, race, error-clears-anchor, clearAll.
+  [`explorer.store.spec.ts:85`](../../frontend/src/tests/stores/explorer.store.spec.ts#L85)

--- a/frontend/src/components/editor/RobotEditor.vue
+++ b/frontend/src/components/editor/RobotEditor.vue
@@ -558,16 +558,15 @@ watch(() => [props.repoId, props.filePath] as const, refreshSidecar, { immediate
 // `keywords` array — so a single refresh call propagates to every
 // editor surface that consults keyword metadata.
 //
-// Triggers:
+// Triggers (only genuine invalidations — keyword data is repo-scoped, so a
+// plain file switch does NOT refresh; see the filePath watcher below):
 //   1. Library / Resource import was added or removed in FlowEditor's
 //      library panel — emitted via `libraries-changed`.
-//   2. `props.filePath` changed — different file may import a
-//      different library set, and the user has likely just saved
-//      changes that the backend should re-introspect.
-//   3. The user switches between testcases / sections inside the
-//      same file — implicitly handled because the keyword cache is
-//      repo-scoped, no extra fetch needed; FlowEditor's existing
-//      reactive bindings rebuild the canvas off the same store.
+//   2. A package was installed via the install dialog.
+//   3. A file save that may have changed imports — handled by ExplorerView's
+//      save handler calling `refreshKeywords`.
+// Switching between testcases / sections inside the same file needs no fetch;
+// FlowEditor's reactive bindings rebuild the canvas off the same store.
 const _explorerStore = useExplorerStore()
 const _reposStore = useReposStore()
 const _envsStore = useEnvironmentsStore()
@@ -780,15 +779,20 @@ async function onLibrariesChanged(addedLibrary?: string): Promise<void> {
   _openInstallDialog(addedLibrary)
 }
 
-// File-switch trigger: refresh once after the new path settles.
-// `immediate: false` so we don't double-fetch when the component
-// mounts (the parent ExplorerView already calls `preloadKeywords` on
-// repo open).
+// File-switch trigger: ENSURE the repo's keywords are loaded — NOT a
+// refresh. Keyword data is repo-scoped (the env's installed libraries and the
+// repo's project keywords don't change between files), so `preloadKeywords`
+// no-ops when this repo is already cached. This is what stops a plain file
+// switch from invalidating the backend libdoc cache + refetching the whole
+// keyword set (and re-showing the loading indicator) every time. Genuine
+// invalidation still happens via `onLibrariesChanged` / install / manual
+// refresh, which call `refreshKeywords`.
 watch(
   () => props.filePath,
   (newPath, oldPath) => {
     if (!newPath || newPath === oldPath) return
-    _refreshKeywordsIfPossible()
+    if (props.repoId == null) return
+    _explorerStore.preloadKeywords(props.repoId).catch(() => { /* non-critical */ })
   },
 )
 

--- a/frontend/src/stores/explorer.store.ts
+++ b/frontend/src/stores/explorer.store.ts
@@ -28,6 +28,15 @@ export const useExplorerStore = defineStore('explorer', () => {
   const keywords = ref<CachedKeyword[]>([])
   const keywordsLoading = ref(false)
   const keywordsLoaded = ref(false)
+  // Which repo the cached `keywords` belong to. Keyword data is repo-scoped
+  // (the env's installed libraries + the repo's project keywords don't change
+  // between files), so `preloadKeywords` can no-op when this already matches —
+  // a plain file switch must NOT refetch the whole repo keyword set.
+  const keywordsRepoId = ref<number | null>(null)
+  // Latest repo requested via preloadKeywords while a load was already in
+  // flight (non-reactive — internal scheduling only). Drained in the loader's
+  // `finally` so the newest repo always wins a fast switch.
+  let pendingKeywordsRepoId: number | null = null
   // User-defined keywords parsed from the repo's own .robot/.resource files.
   // Shared here (rather than owned by KeywordPalette) so useKeywordSignatures
   // can give them precedence over library/BuiltIn keywords — RF resolves
@@ -136,7 +145,15 @@ export const useExplorerStore = defineStore('explorer', () => {
    *  Offline-first: prefer the libdoc-per-environment endpoint (works without
    *  the optional rf-mcp server); fall back to the rf-knowledge search. */
   async function preloadKeywords(repoId: number) {
-    if (keywordsLoading.value) return
+    // Repo-scoped idempotency: already cached for THIS repo → nothing to do.
+    // Lets a file switch call this freely as an "ensure loaded" without ever
+    // triggering a redundant refetch (use `refreshKeywords` to force a reload).
+    if (keywordsLoaded.value && keywordsRepoId.value === repoId) return
+    // A load is already in flight. If it's for a DIFFERENT repo (fast repo
+    // switch mid-fetch), remember the latest wanted repo and re-run when the
+    // in-flight load finishes — otherwise the newer repo's load would be
+    // silently dropped and the palette would show the previous repo's keywords.
+    if (keywordsLoading.value) { pendingKeywordsRepoId = repoId; return }
     keywordsLoading.value = true
     keywordsLoaded.value = false
     try {
@@ -153,6 +170,7 @@ export const useExplorerStore = defineStore('explorer', () => {
               args: k.args || [],
             }))
             keywordsLoaded.value = true
+            keywordsRepoId.value = repoId
             return
           }
           // status "building" with no cached keywords yet → fall through to
@@ -170,11 +188,22 @@ export const useExplorerStore = defineStore('explorer', () => {
         args: r.args || [],
       }))
       keywordsLoaded.value = true
+      keywordsRepoId.value = repoId
     } catch {
-      // Non-critical — palette will just be empty
+      // Non-critical — palette will just be empty. Clear the anchor so it
+      // never advertises a repo whose keywords didn't actually load.
       keywords.value = []
+      keywordsRepoId.value = null
     } finally {
       keywordsLoading.value = false
+      // Service the most recent repo requested while we were loading.
+      if (pendingKeywordsRepoId !== null && pendingKeywordsRepoId !== keywordsRepoId.value) {
+        const next = pendingKeywordsRepoId
+        pendingKeywordsRepoId = null
+        void preloadKeywords(next)
+      } else {
+        pendingKeywordsRepoId = null
+      }
     }
   }
 
@@ -194,12 +223,13 @@ export const useExplorerStore = defineStore('explorer', () => {
     testCases.value = []
     keywords.value = []
     keywordsLoaded.value = false
+    keywordsRepoId.value = null
     projectKeywords.value = []
   }
 
   return {
     tree, selectedFile, searchResults, testCases, loading, currentRepoId,
-    keywords, keywordsLoading, keywordsLoaded, projectKeywords,
+    keywords, keywordsLoading, keywordsLoaded, keywordsRepoId, projectKeywords,
     fetchTree, openFile, searchInRepo, fetchTestCases, clearSelection, clearAll,
     saveFile, createFile, deleteFileAction, renameFileAction, openInEditorAction, openInFileBrowserAction,
     preloadKeywords, refreshKeywords, setProjectKeywords,

--- a/frontend/src/tests/stores/explorer.store.spec.ts
+++ b/frontend/src/tests/stores/explorer.store.spec.ts
@@ -79,3 +79,111 @@ describe('explorer.store preloadKeywords — offline-first', () => {
     expect(explorer.keywords[0].name).toBe('Log')
   })
 })
+
+// Quiet/cached keyword loading (spec-keyword-loading-quiet-and-cached) — a plain
+// file switch must NOT refetch; keyword data is repo-scoped and idempotent.
+describe('explorer.store preloadKeywords — repo-scoped idempotency', () => {
+  beforeEach(() => {
+    setActivePinia(createPinia())
+    mockedSearch.mockReset()
+    mockedEnvKw.mockReset()
+  })
+
+  it('does not refetch when keywords are already loaded for the same repo', async () => {
+    seedDefaultEnv(5)
+    mockedEnvKw.mockResolvedValue({
+      status: 'ready', source_hash: 'h', updated_at: null,
+      keywords: [{ name: 'Click', library: 'Browser', args: ['selector'], shortdoc: '' }],
+    })
+    const explorer = useExplorerStore()
+    await explorer.preloadKeywords(1)
+    expect(explorer.keywordsRepoId).toBe(1)
+    expect(mockedEnvKw).toHaveBeenCalledTimes(1)
+
+    // Simulate file switches within the same repo — must be a no-op.
+    await explorer.preloadKeywords(1)
+    await explorer.preloadKeywords(1)
+    expect(mockedEnvKw).toHaveBeenCalledTimes(1)
+    expect(mockedSearch).not.toHaveBeenCalled()
+  })
+
+  it('does load again when switching to a different repo', async () => {
+    seedDefaultEnv(5)
+    mockedEnvKw.mockResolvedValue({
+      status: 'ready', source_hash: 'h', updated_at: null,
+      keywords: [{ name: 'Click', library: 'Browser', args: [], shortdoc: '' }],
+    })
+    const explorer = useExplorerStore()
+    await explorer.preloadKeywords(1)
+    await explorer.preloadKeywords(2)
+    expect(mockedEnvKw).toHaveBeenCalledTimes(2)
+    expect(explorer.keywordsRepoId).toBe(2)
+  })
+
+  it('refreshKeywords forces a reload even for the same repo', async () => {
+    seedDefaultEnv(5)
+    mockedEnvKw.mockResolvedValue({
+      status: 'ready', source_hash: 'h', updated_at: null,
+      keywords: [{ name: 'Click', library: 'Browser', args: [], shortdoc: '' }],
+    })
+    const explorer = useExplorerStore()
+    await explorer.preloadKeywords(1)
+    expect(mockedEnvKw).toHaveBeenCalledTimes(1)
+    await explorer.refreshKeywords(1)
+    expect(mockedEnvKw).toHaveBeenCalledTimes(2)
+  })
+
+  it('services the latest repo when switched mid-load (no dropped repo)', async () => {
+    seedDefaultEnv(5)
+    let resolveA!: (v: unknown) => void
+    const aPending = new Promise((r) => { resolveA = r })
+    mockedEnvKw
+      .mockReturnValueOnce(aPending) // repo 1 — stays in-flight
+      .mockResolvedValue({
+        status: 'ready', source_hash: 'h', updated_at: null,
+        keywords: [{ name: 'FromRepoTwo', library: 'L', args: [], shortdoc: '' }],
+      })
+    const explorer = useExplorerStore()
+    const p1 = explorer.preloadKeywords(1) // in-flight
+    explorer.preloadKeywords(2)            // queued as pending (not dropped)
+    resolveA({
+      status: 'ready', source_hash: 'h', updated_at: null,
+      keywords: [{ name: 'FromRepoOne', library: 'L', args: [], shortdoc: '' }],
+    })
+    await p1
+    await new Promise((r) => setTimeout(r, 0)) // let the re-run settle
+    expect(explorer.keywordsRepoId).toBe(2)
+    expect(explorer.keywords[0].name).toBe('FromRepoTwo')
+  })
+
+  it('clears the repo anchor when a load fails', async () => {
+    seedDefaultEnv(5)
+    mockedEnvKw.mockResolvedValueOnce({
+      status: 'ready', source_hash: 'h', updated_at: null,
+      keywords: [{ name: 'Click', library: 'Browser', args: [], shortdoc: '' }],
+    })
+    const explorer = useExplorerStore()
+    await explorer.preloadKeywords(1)
+    expect(explorer.keywordsRepoId).toBe(1)
+    // Switch to repo 2; both env + rf-knowledge fail → anchor must not lie.
+    mockedEnvKw.mockRejectedValueOnce(new Error('boom'))
+    mockedSearch.mockRejectedValueOnce(new Error('boom2'))
+    await explorer.preloadKeywords(2)
+    expect(explorer.keywordsRepoId).toBe(null)
+    expect(explorer.keywords).toEqual([])
+  })
+
+  it('clearAll resets the repo anchor so the next preload reloads', async () => {
+    seedDefaultEnv(5)
+    mockedEnvKw.mockResolvedValue({
+      status: 'ready', source_hash: 'h', updated_at: null,
+      keywords: [{ name: 'Click', library: 'Browser', args: [], shortdoc: '' }],
+    })
+    const explorer = useExplorerStore()
+    await explorer.preloadKeywords(1)
+    explorer.clearAll()
+    expect(explorer.keywordsRepoId).toBe(null)
+    await explorer.preloadKeywords(1)
+    expect(mockedEnvKw).toHaveBeenCalledTimes(2)
+  })
+})

--- a/frontend/src/views/ExplorerView.vue
+++ b/frontend/src/views/ExplorerView.vue
@@ -923,9 +923,16 @@ const flatNodes = computed(() => {
       </form>
     </div>
 
-    <!-- Keyword preloading progress bar -->
-    <div v-if="explorer.keywordsLoading" class="keyword-loading-bar">
-      <div class="keyword-loading-bar-inner"></div>
+    <!-- Keyword preloading indicator — deliberately subtle: a slim
+         indeterminate line + a small muted label. Repo-scoped caching means
+         this now only appears on first repo open, not on every file switch. -->
+    <div
+      v-if="explorer.keywordsLoading"
+      class="keyword-loading"
+      role="status"
+      :aria-label="t('explorer.loadingKeywords')"
+    >
+      <span class="keyword-loading-track"><span class="keyword-loading-fill"></span></span>
       <span class="keyword-loading-text">{{ t('explorer.loadingKeywords') }}</span>
     </div>
 
@@ -1786,23 +1793,31 @@ const flatNodes = computed(() => {
   height: 200px;
 }
 
-.keyword-loading-bar {
-  height: 28px;
-  background: var(--color-bg-card);
-  border: 1px solid var(--color-border, #e2e8f0);
-  border-radius: 6px;
-  margin-bottom: 8px;
-  position: relative;
-  overflow: hidden;
+/* Subtle keyword-loading indicator: a 2px indeterminate line + a small,
+   muted caption. No card/border/fill block — it should read as a quiet
+   background hint, not a banner. */
+.keyword-loading {
   display: flex;
   align-items: center;
+  gap: 8px;
+  margin-bottom: 6px;
+  padding: 0 2px;
 }
-.keyword-loading-bar-inner {
+.keyword-loading-track {
+  flex: 1;
+  height: 2px;
+  border-radius: 2px;
+  background: var(--color-border, #e2e8f0);
+  position: relative;
+  overflow: hidden;
+}
+.keyword-loading-fill {
   position: absolute;
   left: 0; top: 0; bottom: 0;
   width: 30%;
   background: var(--color-primary, #3B7DD8);
-  opacity: 0.15;
+  opacity: 0.7;
+  border-radius: 2px;
   animation: keyword-loading-slide 1.5s ease-in-out infinite;
 }
 @keyframes keyword-loading-slide {
@@ -1810,10 +1825,12 @@ const flatNodes = computed(() => {
   100% { left: 100%; }
 }
 .keyword-loading-text {
-  position: relative;
-  z-index: 1;
-  padding: 0 12px;
-  font-size: 13px;
+  flex-shrink: 0;
+  font-size: 11px;
   color: var(--color-text-muted);
+  opacity: 0.8;
+}
+@media (prefers-reduced-motion: reduce) {
+  .keyword-loading-fill { animation: none; width: 100%; opacity: 0.3; }
 }
 </style>


### PR DESCRIPTION
Two related Flow Editor / Explorer keyword-loading improvements (one cohesive change — same root cause), via the bmad-quick-dev flow (clarify → plan → implement → 3-reviewer pass → present).

**Problem:** Switching files re-ran `RobotEditor`'s file-switch watcher → `explorer.refreshKeywords()`, which **invalidated the backend libdoc cache and refetched the whole repo keyword set on every switch** — wasteful (keyword data is repo-scoped: installed libraries + project keywords don't change between files) and it re-flashed the prominent full-width loading bar each time.

## Changes
- **Repo-scoped idempotent cache** — new `keywordsRepoId` anchor; `preloadKeywords` no-ops when the repo is already cached. File-switch watcher now *ensures loaded* instead of invalidate+refetch. Genuine invalidation (libraries-changed, install, save) still uses `refreshKeywords`.
- **Latest-wins scheduling** — a fast repo switch mid-load is no longer silently dropped; error path clears the anchor so it never advertises an unloaded repo. (Both from the review pass.)
- **Subtle indicator** — slim 2px indeterminate line + small muted label (`role="status"`, reduced-motion aware) replacing the full-width bar; now only appears on first repo open, not per file switch.

## Verification
- type-check clean · prod build clean
- store unit suite **10/10** (idempotency, cross-repo reload, refresh-forces-reload, race, error-clears-anchor, clearAll)
- e2e (explorer + flow-editor-resource-ux) **32/32**

Spec: `_bmad-output/implementation-artifacts/spec-keyword-loading-quiet-and-cached.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)